### PR TITLE
Waive the HelpCircuit's verifying key group checking in the MainCircuit

### DIFF
--- a/src/ec_cycle_pcd/data_structures.rs
+++ b/src/ec_cycle_pcd/data_structures.rs
@@ -155,8 +155,10 @@ impl<
             HelpField,
             MainField,
             IC::HelpSNARK,
-        >>::VerifyingKeyVar::new_witness(
-            ark_relations::ns!(cs, "alloc#vk"), || Ok(help_vk)
+        >>::new_verification_key_unchecked(
+            ark_relations::ns!(cs, "alloc#vk"),
+            || Ok(help_vk),
+            AllocationMode::Witness,
         )?;
 
         let msg = self.msg.unwrap_or_default();


### PR DESCRIPTION
Currently, in the MainCircuit, `pcd` allocates the verifying key of the HelpCircuit using `new_witness`, which includes the subgroup checks (for G_2 in many cases). 

This turns out to be very costly and unnecessary---since a hash value of the verifying key is computed and fixed in the PCD system. Therefore, this check can be waived, which provides a significant performance improvement.

The arkworks implementations of Groth16 and GM17 already provide interfaces to allocate the verifying key without subgroup checks.

However, such a test is currently missing in Marlin, which would be added soon. Note that the case for Marlin is very different. Particularly, for Marlin, commitments are always in G_1 so no check is needed for the indexed commitments. One thing to check is whether Marlin's verifying key for poly-commit, which can be fixed independent of the circuit, is allocated in this way. 