### PR TITLE
Use crates-io dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,32 +13,32 @@ edition = "2018"
 ################################# Dependencies ################################
 
 [dependencies]
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra", default-features = false, features = [ "derive" ] }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra", default-features = false }
+ark-serialize = { version = "0.3", default-features = false, features = [ "derive" ] }
+ark-ff = { version = "0.3", default-features = false }
+ark-ec = { version = "0.3", default-features = false }
+ark-poly = { version = "0.3", default-features = false }
 
-ark-std = { git = "https://github.com/arkworks-rs/utils", default-features = false }
+ark-std = { version = "0.3", default-features = false }
 
-ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features = false }
-ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", default-features = false, branch = "main", features = [ "r1cs" ] }
+ark-relations = { version = "0.3", default-features = false }
+ark-crypto-primitives = { version = "0.3", default-features = false, features = [ "r1cs" ] }
 
-ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-features = false }
+ark-r1cs-std = { version = "0.3", default-features = false }
 
-ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false }
-ark-snark = { git = "https://github.com/arkworks-rs/snark", default-features = false }
+ark-nonnative-field = { version = "0.3", default-features = false }
+ark-snark = { version = "0.3", default-features = false }
 
-ark-ed-on-mnt4-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false }
-ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-features = false }
-ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "curve", "r1cs" ] }
-ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "r1cs" ] }
+ark-ed-on-mnt4-298 = { version = "0.3", default-features = false }
+ark-ed-on-bls12-381 = { version = "0.3", default-features = false }
+ark-mnt4-298 = { version = "0.3", default-features = false, features = [ "curve", "r1cs" ] }
+ark-mnt6-298 = { version = "0.3", default-features = false, features = [ "r1cs" ] }
 
 rand_chacha = { version = "0.2.1", default-features = false }
 derivative = { version = "2.0", features = ["use_core"] }
 
-ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", features = [ "r1cs" ], default-features = false }
-ark-gm17 = { git = "https://github.com/arkworks-rs/gm17", features = [ "r1cs" ], default-features = false }
-ark-marlin = { git = "https://github.com/arkworks-rs/marlin", branch = "constraints", default-features = false }
+ark-groth16 = { version = "0.3", features = [ "r1cs" ], default-features = false }
+ark-gm17 = { version = "0.3", features = [ "r1cs" ], default-features = false }
+ark-marlin = { git = "https://github.com/arkworks-rs/marlin", branch = "vlopes11/constraints", default-features = false }
 ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit", branch = "constraints", default-features = false, features = [ "r1cs" ] }
 
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ] }


### PR DESCRIPTION
Using git as dependencies will downstream break the library in case of
unreleased unstable active development.

It is desirable to use properly published and tagged dependencies in
order to improve overall stability.

Closes #7